### PR TITLE
Literals on each line

### DIFF
--- a/src/lib/__tests__/astTest.ts
+++ b/src/lib/__tests__/astTest.ts
@@ -1,0 +1,19 @@
+import { dts } from '../ast';
+
+describe('ast', () => {
+  describe('dts', () => {
+    it('includes MessageKey type definition', () => {
+      const keys = [
+        { key: 'foo', value: 'foo-val', interpolations: [] },
+        { key: 'bar', value: 'bar-val', interpolations: [] },
+        { key: 'baz', value: 'baz-val', interpolations: [] },
+      ];
+      const result = dts(keys);
+      const expected = `type MessageKey =
+  | "foo"
+  | "bar"
+  | "baz";`;
+      expect(result.includes(expected)).toBeTruthy();
+    });
+  });
+});

--- a/src/lib/__tests__/fileTest.ts
+++ b/src/lib/__tests__/fileTest.ts
@@ -71,7 +71,9 @@ describe('file', () => {
 
     it('returns error with wrong file extension', () => {
       const error = getTranslationFromModel(
-        path.resolve('./src/lib/__tests__/fixtures/wrong_ext_name/package.jsonp'),
+        path.resolve(
+          './src/lib/__tests__/fixtures/wrong_ext_name/package.jsonp',
+        ),
       );
       expect(error instanceof Error).toBeTruthy();
       expect((error as Error).message).toEqual(
@@ -85,7 +87,7 @@ describe('file', () => {
       );
       expect(config instanceof Error).toBeFalsy();
       expect(config).toEqual({
-        'i18n-dts': {
+        'react-intl-dts': {
           model: './en.json',
           outputDir: './typings',
         },

--- a/src/lib/__tests__/fixtures/valid/package.json
+++ b/src/lib/__tests__/fixtures/valid/package.json
@@ -1,5 +1,5 @@
 {
-  "i18n-dts": {
+  "react-intl-dts": {
     "model": "./en.json",
     "outputDir": "./typings"
   }

--- a/src/lib/ast.ts
+++ b/src/lib/ast.ts
@@ -4,7 +4,9 @@ import { Translation } from '../interfaces';
 
 export const dts = (keys: Translation[]): string => {
   const declareType =
-    'type MessageKey =' + keys.map(key => `"${key.key}"`).join('|') + ';\n\n';
+    'type MessageKey =\n' +
+    keys.map(key => `  | "${key.key}"`).join('\n') +
+    ';\n\n';
   const origPath = join(__dirname, '../../assets/react-intl.d.ts');
   const orig = readFileSync(origPath, { encoding: 'utf-8' });
 


### PR DESCRIPTION
Close #1 

It will solve conflict and large diff for pull requests.

I've confirmed this patch does not change meanings of type definitions by running `tsc` with our application (kibela).


FYI @bitjourney/engineers 