### PR TITLE
Sort types alphabetically

### DIFF
--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -14,6 +14,7 @@ export const generate = (
     mkdirp.sync(dirPath);
   }
   const keys = flattenKeys(translations);
+  keys.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
   const data = dts(keys);
   const outputPath = path.join(dirPath, OUTPUT_FILE_NAME);
   return execWriteFile(outputPath, data);


### PR DESCRIPTION
Close #6 


FYI @bitjourney/engineers 

Problem
===

Our translation SaaS re-orders the translation files.
So it causes conflict of the d.ts file.

Solution
====

Sort the keys alphabetically.


Note
===


The order by react-intl-dts is not exactly the same as the SaaS's one.
Because the SaaS treats capital letter and small letter as the same, but react-intl-dts treats them as different characters.

But this difference is not problematic.
Because the main problem is the generated file's order depends on the translation file.
The problem is solved by this change.